### PR TITLE
Fix README: use fully qualified cask install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,8 @@
 
 ## Installation (Recommended)
 
-Install saucectl as a Homebrew Cask:
-
 ```
-brew install --cask saucectl
-```
-
-Or, if you haven't tapped yet:
-
-```
-brew tap saucelabs/saucectl
-brew install --cask saucectl
+brew install --cask saucelabs/saucectl/saucectl
 ```
 
 ## Deprecated Formula
@@ -22,7 +13,7 @@ The old formula-based installation (`brew install saucelabs/saucectl/saucectl`) 
 
 ```
 brew uninstall saucectl
-brew install --cask saucectl
+brew install --cask saucelabs/saucectl/saucectl
 ```
 
 ## Documentation


### PR DESCRIPTION
## Summary
- `brew install --cask saucectl` doesn't work without tapping first
- Changed to `brew install --cask saucelabs/saucectl/saucectl` which auto-taps and installs in one step
- Updated migration instructions to use the same fully qualified form